### PR TITLE
Add instructions for setting postgres passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Create a new communityshare user
  # CREATE USER communityshare;
 ```
 
+Set the communityshare user password (Set it to "communityshare", otherwise you will need to edit config.json)
+
+```
+\password communityshare
+```
+
 Create a new communityshare database
 
 ```


### PR DESCRIPTION
On linux with a fresh install of postgres, I needed to set the password of the communityshare user before `python3 setup.py` was able to connect.

If someone wants to check that this work on mac that would be ideal, but in the meantime it might be nice to keep for reference.