### PR TITLE
Remove email confirmation requirement

### DIFF
--- a/community_share/models/user.py
+++ b/community_share/models/user.py
@@ -58,7 +58,7 @@ class User(Base, Serializable):
     id = Column(Integer, primary_key=True)
     name = Column(String(50), nullable=False)
     email = Column(String(50), nullable=False)
-    email_confirmed = Column(Boolean, nullable=False, default=False)
+    email_confirmed = Column(Boolean, nullable=False, default=True)
     active = Column(Boolean, default=True)
     password_hash = Column(String(120), nullable=True)
     date_created = Column(DateTime, nullable=False, default=datetime.utcnow)


### PR DESCRIPTION
Email confirmations will still be sent (and possibly other things) but
users won't be blocked from doing things, since their email_confirmed
field will be set to true upon account creation.