### PR TITLE
Profile Pictures: Refactor upload handling code

### DIFF
--- a/community_share/picture_utils.py
+++ b/community_share/picture_utils.py
@@ -1,0 +1,31 @@
+import hashlib
+import imghdr
+
+from community_share.s3_connection import save_file_to_s3
+
+
+def get_image_type(image_data):
+    return imghdr.what('ignored', h=image_data)
+
+
+def image_to_user_filename(image_data, user_id):
+    image_type = get_image_type(image_data)
+
+    return 'user_{0:d}_{1}.{2}'.format(
+        user_id,
+        hashlib.sha1(image_data).hexdigest(),
+        image_type if image_type is not 'jpeg' else 'jpg'
+    )
+
+
+def is_allowable_image(image_data):
+    # _not_ extensions, but types from imghdr
+    # if unrecognized, type will be None
+    return get_image_type(image_data) in ['gif', 'jpeg', 'png']
+
+
+def store_image(src_filename, dst_filename):
+    try:
+        save_file_to_s3(src_filename, dst_filename)
+    except:
+        return

--- a/community_share/s3_connection.py
+++ b/community_share/s3_connection.py
@@ -1,0 +1,18 @@
+import tinys3
+
+from community_share import config
+
+
+def save_file_to_s3(src_filename, dst_filename):
+    conn = tinys3.Connection(
+        config.S3_USERNAME,
+        config.S3_KEY,
+        tls=True
+    )
+
+    conn.upload(
+        dst_filename,
+        src_filename,
+        config.S3_BUCKETNAME,
+        expires=3600  # cache-expiry = 1 hour
+    )


### PR DESCRIPTION
Precursor to #71
Should prevent problems described in #15

This patch refactors a fair bit of code surrounding the way user profile
pictures are uploaded and saved. The existing process is full of nested
blocks and hard-coded information, preventing some flexibility in the
way we deal with uploads.

The refactor should provide the following benefits:

 - Image types are recognized from their actual data and not from the
   file extension. This closes off the possibility to defeat the rule by
   simply changing the filename. The new check relies on the built-in
   `imghdr` library in Python

 - Some image operations have been modularized in order to isolate and
   simplify their behaviors. This should allow incorporating
   alternatives to the S3 storage, such as for when developing locally.

These changes alter the way the image filenames are generated.
Previously, the stored filename was a function of the first fifty
characters in the uploaded filename. Now, the filename is generated as a
function of the SHA1 hash of the uploaded file contents, which not only
greatly limits the range of characters sent as the filename (no possible
encoding issues, for example), but also ends up mapping identical images
to identical filenames, regardless of the given name.

This last point about mapping to the same name could carry a negative
implication: we could end up having two references to the same file and
accidentally delete "both" because we deleted the singular mapping
endpoint. It does not appear like this will be a problem given the way
the app is structured.

_Example_

 - User uploads profile picture
 - User uploads picture for some other use, but the contents are
   identical to the profile picture
 - User deletes this picture, but since it shares the same filename as
   the profile picture (they are identical), both get erased.

This new file naming behavior is more regular and standard than the
existing formula, but we could just as easily reproduce the old behavior
by updating the `image_to_user_filename()` function.

**There are no stylistic or visual changes in this PR**

cc: @benreynwar 