### PR TITLE
Fix some deployment bugs:

### DIFF
--- a/community_share/__init__.py
+++ b/community_share/__init__.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import json
+import sys
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
@@ -20,6 +21,8 @@ def setup_logging(level, location):
     if not os.path.exists(logging_fn):
         open(logging_fn, 'a').close()
     ch = logging.FileHandler(logging_fn)
+    if location == "STDOUT":
+        ch = logging.StreamHandler(stream=sys.stdout)
     ch.setLevel(level)
     formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     ch.setFormatter(formatter)

--- a/community_share/mail.py
+++ b/community_share/mail.py
@@ -102,7 +102,7 @@ class DummyMailer(object):
 class MailgunMailer(object):
     def send(email):
         error_message = ''
-        if not (email.endswith('@example.com')):
+        if not (email.to_address.endswith('@example.com')):
             payload = {
                 'from': email.from_address,
                 'to': email.to_address,

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
 "BASEURL":                  "http://0.0.0.0:5000",
 "BUG_EMAIL_ADDRESS":        "tech@example.com",
 "DONOTREPLY_EMAIL_ADDRESS": "CommunityShare <support@example.com>",
-"ENCRYPTION_KEY":           "AAAAA",
+"ENCRYPTION_KEY":           "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
 "LOGGING_LEVEL":            "DEBUG",
 "MAILER_TYPE":              "DUMMY",
 "NOTIFY_EMAIL_ADDRESS":     "notify@example.com",


### PR DESCRIPTION
What was broken?
 - The encryption key for the local-dev `config.json` file wasn't long
   enough, which caused the encryption module to fail.

 - There was a typo introduced in `mail.py` in <del>9c7ec941</del><ins> ba299b93b30a110960e85139eb85cb7e94d05175</ins> which meant that
   the mailer was trying to invoke a method on an undefined property and
   was consequently failing. This was causing failure in production when
   sending messages, causing a 500 INTERNAL SERVER ERROR.

 - The logging for production, when the location in `config.json` is set
   to STDOUT, wasn't redirecting the output to standard out. This was
   hiding errors on Heroku

**Testing**
Login and send a message. If it's still broken you will find a 500 status after sending the message.

cc: @benreynwar @seanastephens 