### PR TITLE
Add production/development status to config and safeguard deployment

### DIFF
--- a/community_share/__init__.py
+++ b/community_share/__init__.py
@@ -64,6 +64,7 @@ store = Store()
 
 class Config(object):
     NAMES = (
+        'APP_ENV',  # 'development' or 'production'
         # Database
         'DB_CONNECTION',
         # Email 
@@ -98,6 +99,7 @@ class Config(object):
 
     def load_from_environment(self):
         data = {
+            'APP_ENV': os.environ['APP_ENV'],
             'DB_CONNECTION': os.environ['DATABASE_URL'],
             'MAILER_TYPE': os.environ['COMMUNITYSHARE_MAILER_TYPE'],
             'MAILGUN_API_KEY': os.environ['MAILGUN_API_KEY'],

--- a/community_share_app.py
+++ b/community_share_app.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from community_share import config, app
 
@@ -6,6 +7,10 @@ logger = logging.getLogger(__name__)
 
 logger.info('Loading settings from environment')
 config.load_from_file()
+
+if not 'production' == config.APP_ENV:
+    sys.exit('Cannot run production app without production config')
+
 logger.info('Making application')
 app = app.make_app()
 app.debug = False

--- a/community_share_local_app.py
+++ b/community_share_local_app.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from community_share import config, app
 
@@ -6,6 +7,10 @@ logger = logging.getLogger(__name__)
 
 logger.info('Loading settings from environment')
 config.load_from_file()
+
+if 'production' == config.APP_ENV:
+    sys.exit('Cannot run development app with production config')
+
 logger.info('Making application')
 app = app.make_app()
 app.debug = True

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+"APP_ENV":                  "development",
 "COMMIT_HASH":              "blah",
 "ABUSE_EMAIL_ADDRESS":      "support@example.com",
 "ADMIN_EMAIL_ADDRESSES":    "another-admin@example.com",


### PR DESCRIPTION
Previously the app performed no checking and recorded no state of
whether or not we were running in production or locally while
developing/testing. Unfortunately, I accidentally ran the local
development server with the production config, which led to the
initialization script connecting to the production database, wiping it,
and loading random data into it.

This patch adds a new variable into the config to explicitly specify
which environment is running and adds some safeguards to prevent
accidentally doing what I did. It will not run the production script
without `config.APP_ENV == 'production'` nor will it run the local
development script _with_ `config.APP_ENV == 'production'`.

While it will still be possible to wipe the database or connect
improperly, this should protect against the accidental case I ran into.

**Testing**

There are two modes this should protect against: starting the production script without the production config; starting the development script _with_ the production config.

 - Change `APP_ENV` to `production` in the `config.json` file and attempt to start the server. It should fail with a message.
 - Remove the `APP_ENV` key from `config.json` and attempt to start the server. It should fail specifying that it requires the key.
 - Testing in production?? We'll have to deploy and see…

cc: @seanastephens @benreynwar 