### PR TITLE
add env and communitysharelogs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ instance/
 
 static/build
 manifest.json
+env
+communitysharelogs
 
 \#*
 \.\#*


### PR DESCRIPTION
**What did you change?**
I added `env` and `communitysharelogs`to the gitignore. This allows the project to be self-contained (all files and folders inside the project directory) and is helpful when doing non-docker local development.

**How can someone else test it?**
Create a virtualenv in the project root called `env` and configure the code to write logs to a `communitysharelogs` folder at the project. If both folders are excluded from git, it works.