### PR TITLE
fix spelling of administrator

### DIFF
--- a/static/js/directives/institution_directives.js
+++ b/static/js/directives/institution_directives.js
@@ -57,9 +57,9 @@ module.directive(
 						'Other',
 					];
 					$scope.roles = [
-						'Classroom teacher',
+						'Classroom Teacher',
 						'Curriculum Coordinator',
-						'Administator',
+						'Administrator',
 						'Parent',
 						'Other',
 					];


### PR DESCRIPTION
**What did you change?**
This PR fixes the spelling of "Administrator" in the "Role" dropdown when a new teacher signs up. It currently says "AdminiSTATOR" (no R).

![screen_shot_2017-02-12_at_10_30_34_pm](https://cloud.githubusercontent.com/assets/2637399/22871999/293b6dae-f173-11e6-97fc-33bc7f0bca93.png)

**How can someone else test it?**
1. Create a new account. Select "Teacher" as your profile type.
2. Verify that "Administrator" is spelled correctly in the "Role" dropdown.
