### PR TITLE
duplicate share button at top of conversation

### DIFF
--- a/static/templates/conversation.html
+++ b/static/templates/conversation.html
@@ -22,6 +22,15 @@
         Don't forget to Create a Share.
       </div>
 
+      <div class="chat-button-area">
+        <div class="row">
+          <button class="btn btn-success"
+                  type="submit"
+                  ng-click="createNewShare()">Create a New Share
+          </button>
+        </div>
+      </div>
+
       <div id="chat-header">
         <div class="row">
           <div class="col-lg-2">


### PR DESCRIPTION
**What did you change?**

This PR duplicates the "Create a Share" button and adds it to the top of a conversation. This is intended to make it easier for people to notice it, as a common question is "how do I create a share". At the bottom of the page the button is easily missed.

The button is being left on the button of the page as well for anyone who already looks for it there.

![community_share](https://cloud.githubusercontent.com/assets/2637399/22872201/7efba294-f174-11e6-91cf-87b72d863778.png)

**How can someone else test it?**
Navigate to a conversation you have with someone (between a teacher and a partner) and click the button at the top of the page to create a share.