### PR TITLE
disable polling to fix profile editing

### DIFF
--- a/static/js/controllers/conversation_controllers.js
+++ b/static/js/controllers/conversation_controllers.js
@@ -118,8 +118,8 @@ module.controller(
 		$scope.messageHighlightClasses[ Session.activeUser.id ] = 'highlight1';
 		$scope.messageHighlightClasses[ $scope.otherUser.id ] = 'highlight2';
 		$scope.newMessage = makeNewMessage();
-		refreshShares();
-		$timeout( refreshConversation, 5000 );
+		// refreshShares();
+		// $timeout( refreshConversation, 5000 );
 		$scope.createNewShare = function() {
 			var share = conversation.makeShare();
 			$scope.editShare( share );


### PR DESCRIPTION
**What did you change?**
This PR disables the polling behavior for conversations. Currently, when a user navigates to a conversation, it polls the server for new messages every 5 seconds. This feature (I assume) exists to enable the ability to perform real-time chat.

The problem lies in the fact that this polling behavior doesn't get disabled when the user leaves the conversation. And when the data arrives, the application is updated.

If a user views a conversation, and then navigates to their profile (perhaps to edit their profile description) this polling behavior causes any changes the user makes to be thrown out every 5 seconds. This makes it impossible to update the profile without copy/pasting content from an external text editor, to try and make the change within the 5 seconds window.

This PR disables the polling behavior in order to preserve the expected behavior of pages that require the user to edit information.

![community_share 2](https://cloud.githubusercontent.com/assets/2637399/22872475/be55438a-f176-11e6-91c3-08f253c78996.png)

**How can someone else test it?**
1. Navigate to a conversation.
2. Click the "Settings" dropdown in the header, and select "Edit my Profile".
3. Start editing your profile description. Wait 5 seconds. Verify that changes you may still exist in the textarea field.

@dmsnell
